### PR TITLE
github linguist git attributes for oberon.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Set the language to Oberon
+*.Mod linguist-language=Oberon
+*.mod linguist-language=Oberon


### PR DESCRIPTION
apparently github's linguist can now mark source as oberon, but we need to tell it that our .Mod files are oberon files.